### PR TITLE
Fixing an array boundary overflow issue

### DIFF
--- a/geohash.c
+++ b/geohash.c
@@ -85,7 +85,7 @@ char* get_neighbor(char *hash, int direction) {
     
     char *base = malloc(sizeof(char) * hash_length);
     base[0] = '\0';
-    strncat(base, hash, hash_length - 1);
+    strlcat(base, hash, hash_length - 1);
     
 	if(index_for_char(last_char, border[direction]) != -1)
 		base = get_neighbor(base, direction);

--- a/geohash.c
+++ b/geohash.c
@@ -83,7 +83,7 @@ char* get_neighbor(char *hash, int direction) {
     char **border = is_odd ? odd_borders : even_borders;
     char **neighbor = is_odd ? odd_neighbors : even_neighbors; 
     
-    char *base = malloc(sizeof(char) * 1);
+    char *base = malloc(sizeof(char) * hash_length);
     base[0] = '\0';
     strncat(base, hash, hash_length - 1);
     


### PR DESCRIPTION
Just applied a quick fix to the get_neighbor method.
1. The 1st argument in a call to strncat should have enough place to store the result.
2. strncat is a bit buggy when _FORTIFY_SOURCE is being used and Xcode uses that when targeting an iOS device. So I have replaced the call to strcat with a safer version of strlcat, which in addition doesn't have that bug.

More info can be found at: http://www.cocoabuilder.com/archive/xcode/266956-fortify-source-and-strncat-buggy.html

Another workaround would be to use _FORTIFY_SOURCE=0 but then you'll loose all the sanity checks performed when that is non-zero.
